### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete multi-character sanitization

### DIFF
--- a/src/ts/utils/text-sanitizer.ts
+++ b/src/ts/utils/text-sanitizer.ts
@@ -29,8 +29,11 @@ const DEFAULT_OPTIONS: SanitizeOptions = {
 
 /**
  * HTML tag patterns to remove
+ *
+ * We strip all angle brackets rather than trying to parse HTML tags,
+ * which avoids incomplete multi-character sanitization issues.
  */
-const HTML_TAG_PATTERN = /<[^>]*>/g;
+const HTML_TAG_PATTERN = /[<>]/g;
 
 /**
  * Shell metacharacter patterns to remove


### PR DESCRIPTION
Potential fix for [https://github.com/madeinoz67/madeinoz-voice-server/security/code-scanning/4](https://github.com/madeinoz67/madeinoz-voice-server/security/code-scanning/4)

In general, the safest fix is to avoid ad‑hoc HTML/script regexes and instead either (a) use a well‑tested HTML sanitization library, or (b) fall back to very simple, character‑oriented rules (e.g., removing `<` and `>` altogether) when you only need plain text. In this code, `sanitizeText` is for TTS and notification titles/messages, where HTML is not needed, so the simplest robust fix is to strip all `<` and `>` characters instead of trying to parse tags.

To fix this specific issue without changing intended functionality:

1. Replace the current HTML‑tag regex `/\<[^>]*\>/g` with a plain character regex `/[<>]/g` so that *all* angle brackets are removed, making script tags and other HTML elements impossible.
2. Optionally, since we no longer try to allow HTML, the complex `SCRIPT_PATTERN` becomes redundant; we can keep it for defensive validation in `isValidText`, but the main safety now comes from stripping `<` and `>` individually. To keep changes minimal, we’ll leave `SCRIPT_PATTERN` as‑is.
3. Keep the rest of the logic (shell chars stripping, whitespace normalization, maxLength) unchanged.

Concretely:

- In `src/ts/utils/text-sanitizer.ts`, change the `HTML_TAG_PATTERN` definition (line 33) from `/<[^>]*>/g` to `/[<>]/g`. This ensures we are no longer doing multi‑character “tag” replacement; instead, we remove every `<` and `>` character, which closes the incomplete multi‑character sanitization issue highlighted by CodeQL while preserving the goal: no HTML/script tags can survive into the TTS/notification layer.

No new imports or helper methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
